### PR TITLE
switch to cross-fetch

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,15 +1,15 @@
-const isoFetch = require('isomorphic-fetch')
+const crossFetch = require('cross-fetch')
 const patchRequest = require('./lib/patchRequest')
 const patchResponse = require('./lib/patchResponse')
 
 function fetch (url, options) {
   return patchRequest(options).then((options) => {
-    return isoFetch(url, options).then((res) => {
+    return crossFetch(url, options).then((res) => {
       return patchResponse(res)
     })
   })
 }
 
-fetch.Headers = global.Headers
+fetch.Headers = crossFetch.Headers
 
 module.exports = fetch

--- a/lib/patchResponse.js
+++ b/lib/patchResponse.js
@@ -17,7 +17,6 @@ function patch (res) {
       body: new WhatwgReadable(res.body.getReader())
     })
   } else if (res.body && res.body.readable) {
-    res.body = res.body
   } else {
     res.body = new ArrayBufferReadable(() => {
       return res.arrayBuffer()

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   },
   "scripts": {
     "test": "standard && mocha",
-    "test-browser": "mkdir -p .build && browserify -d test/*.js > .build/index.js"
+    "test-browser": "mkdir -p .build && webpack test/*.js -o .build/index.js --mode development"
   },
   "repository": {
     "type": "git",
@@ -27,15 +27,16 @@
   "homepage": "https://github.com/bergos/nodeify-fetch",
   "dependencies": {
     "concat-stream": "^1.6.0",
-    "isomorphic-fetch": "^2.2.1",
+    "cross-fetch": "^3.0.4",
     "readable-error": "^1.0.0",
-    "readable-stream": "^2.2.6"
+    "readable-stream": "^3.5.0"
   },
   "devDependencies": {
-    "bluebird": "^3.5.0",
-    "browserify": "^14.4.0",
-    "express": "^4.15.2",
-    "mocha": "^3.2.0",
-    "standard": "^10.0.3"
+    "express": "^4.17.1",
+    "express-as-promise": "0.0.1",
+    "mocha": "^7.0.0",
+    "standard": "^14.3.1",
+    "webpack": "^4.41.5",
+    "webpack-cli": "^3.3.10"
   }
 }

--- a/test/ArrayBufferReadable.js
+++ b/test/ArrayBufferReadable.js
@@ -1,11 +1,11 @@
 /* global describe, it */
 
-const assert = require('assert')
+const { deepStrictEqual, strictEqual } = require('assert')
 const ArrayBufferReadable = require('../lib/ArrayBufferReadable')
 
 describe('ArrayBufferReadable', () => {
   it('should be a constructor', () => {
-    assert.equal(typeof ArrayBufferReadable, 'function')
+    strictEqual(typeof ArrayBufferReadable, 'function')
   })
 
   it('should emit an end event', () => {
@@ -31,7 +31,7 @@ describe('ArrayBufferReadable', () => {
 
     return new Promise((resolve) => {
       readable.on('data', (chunk) => {
-        assert.deepEqual(chunk, arrayBuffer)
+        deepStrictEqual(chunk, arrayBuffer)
 
         resolve()
       })

--- a/test/Headers.js
+++ b/test/Headers.js
@@ -1,5 +1,6 @@
+/* global describe, it */
+
 const { strictEqual } = require('assert')
-const { describe, it } = require('mocha')
 const { Headers } = require('..')
 
 describe('Headers', () => {
@@ -12,6 +13,7 @@ describe('Headers', () => {
 
     strictEqual(typeof headers.append, 'function')
     strictEqual(typeof headers.delete, 'function')
+    strictEqual(typeof headers.entries, 'function')
     strictEqual(typeof headers.get, 'function')
     strictEqual(typeof headers.has, 'function')
     strictEqual(typeof headers.set, 'function')

--- a/test/PatchableResponse.js
+++ b/test/PatchableResponse.js
@@ -1,11 +1,11 @@
 /* global describe, it */
 
-const assert = require('assert')
+const { deepStrictEqual, notStrictEqual, strictEqual } = require('assert')
 const PatchableResponse = require('../lib/PatchableResponse')
 
 describe('PatchableResponse', () => {
   it('should be a constructor', () => {
-    assert.equal(typeof PatchableResponse, 'function')
+    strictEqual(typeof PatchableResponse, 'function')
   })
 
   it('should wrap methods of the object', () => {
@@ -22,8 +22,8 @@ describe('PatchableResponse', () => {
 
     res.test()
 
-    assert.notEqual(res.test, obj.test)
-    assert(touched)
+    notStrictEqual(res.test, obj.test)
+    strictEqual(touched, true)
   })
 
   it('should wrap properties of the object', () => {
@@ -42,11 +42,11 @@ describe('PatchableResponse', () => {
     const obj = new Test()
     const res = new PatchableResponse(obj, {})
 
-    assert.equal(res.test, 'initial')
+    strictEqual(res.test, 'initial')
 
     res.test = 'changed'
 
-    assert.equal(res.test, 'changed')
+    strictEqual(res.test, 'changed')
   })
 
   it('should use patched properties and methods', () => {
@@ -70,8 +70,8 @@ describe('PatchableResponse', () => {
       method: method
     })
 
-    assert.equal(res.property, 'patched')
-    assert.equal(res.method(), 'patched')
+    strictEqual(res.property, 'patched')
+    strictEqual(res.method(), 'patched')
   })
 
   it('.properties should list all properties of the class', () => {
@@ -82,6 +82,6 @@ describe('PatchableResponse', () => {
 
     const properties = PatchableResponse.properties(new Test())
 
-    assert.deepEqual(properties, ['constructor', 'test0', 'test1'])
+    deepStrictEqual(properties, ['constructor', 'test0', 'test1'])
   })
 })

--- a/test/WhatwgReadable.js
+++ b/test/WhatwgReadable.js
@@ -1,17 +1,17 @@
 /* global describe, it */
 
-const assert = require('assert')
+const { strictEqual } = require('assert')
 const WhatwgReadable = require('../lib/WhatwgReadable')
 
 describe('WhatwgReadable', () => {
   it('should be a constructor', () => {
-    assert.equal(typeof WhatwgReadable, 'function')
+    strictEqual(typeof WhatwgReadable, 'function')
   })
 
   it('should emit an end event', () => {
     const whatwg = {
       read: () => {
-        return Promise.resolve({done: true})
+        return Promise.resolve({ done: true })
       }
     }
 
@@ -30,9 +30,9 @@ describe('WhatwgReadable', () => {
     const whatwg = {
       read: () => {
         if (counter > 0) {
-          return Promise.resolve({value: 'test'})
+          return Promise.resolve({ value: 'test' })
         } else {
-          return Promise.resolve({done: true})
+          return Promise.resolve({ done: true })
         }
       }
     }
@@ -41,7 +41,7 @@ describe('WhatwgReadable', () => {
 
     return new Promise((resolve) => {
       readable.on('data', (chunk) => {
-        assert.equal(chunk, 'test')
+        strictEqual(chunk.toString(), 'test')
 
         counter--
       })
@@ -61,7 +61,7 @@ describe('WhatwgReadable', () => {
 
     return new Promise((resolve) => {
       readable.on('error', (err) => {
-        assert.equal(err.message, 'test')
+        strictEqual(err.message, 'test')
 
         resolve()
       })

--- a/test/fetch.js
+++ b/test/fetch.js
@@ -1,6 +1,6 @@
-/* global before, describe, it */
+/* global after, before, describe, it */
 
-const assert = require('assert')
+const { strictEqual } = require('assert')
 const fetch = require('..')
 const server = require('./support/server')
 
@@ -13,10 +13,14 @@ describe('fetch', () => {
     }
   })
 
+  after(() => {
+    return server.stop()
+  })
+
   it('response .body should be a stream', () => {
     return fetch('http://localhost:8081/plain-text').then((response) => {
-      assert.equal(typeof response.body, 'object')
-      assert.equal(response.body.readable, true)
+      strictEqual(typeof response.body, 'object')
+      strictEqual(response.body.readable, true)
     })
   })
 
@@ -26,7 +30,7 @@ describe('fetch', () => {
         let content = ''
 
         response.body.on('end', () => {
-          assert.equal(content, 'text')
+          strictEqual(content, 'text')
 
           resolve()
         })

--- a/test/patchRequest.js
+++ b/test/patchRequest.js
@@ -1,6 +1,6 @@
 /* global describe, it */
 
-const assert = require('assert')
+const { deepStrictEqual, strictEqual } = require('assert')
 const patchRequest = require('../lib/patchRequest')
 const Readable = require('readable-stream')
 
@@ -12,35 +12,38 @@ describe('patchRequest', () => {
   it('should ignore the body if it\'s not a stream', () => {
     const body = 'test'
 
-    return patchRequest({body: body}).then((options) => {
-      assert.equal(options.body, body)
+    return patchRequest({ body }).then((options) => {
+      strictEqual(options.body, body)
     })
   })
 
   it('should convert a string stream to a string', () => {
-    const body = new Readable()
-    const content = ['test', '1234']
+    const body = new Readable({
+      objectMode: true,
+      read: () => {
+        body.push('test')
+        body.push('1234')
+        body.push(null)
+      }
+    })
 
-    body._read = () => {
-      body.push(content.shift() || null)
-    }
-
-    return patchRequest({body: body}).then((options) => {
-      assert.equal(options.body, 'test1234')
+    return patchRequest({ body }).then((options) => {
+      strictEqual(options.body, 'test1234')
     })
   })
 
   it('should convert a buffer stream to a string', () => {
-    const body = new Readable()
-    const content = [Buffer.from('test'), Buffer.from('1234')]
+    const body = new Readable({
+      read: () => {
+        body.push(Buffer.from('test'))
+        body.push(Buffer.from('1234'))
+        body.push(null)
+      }
+    })
 
-    body._read = function () {
-      body.push(content.shift() || null)
-    }
-
-    return patchRequest({body: body}).then((options) => {
-      assert.equal(Buffer.isBuffer(options.body), true)
-      assert.deepEqual(options.body, Buffer.from('test1234'))
+    return patchRequest({ body }).then((options) => {
+      strictEqual(Buffer.isBuffer(options.body), true)
+      deepStrictEqual(options.body, Buffer.from('test1234'))
     })
   })
 })

--- a/test/patchResponse.js
+++ b/test/patchResponse.js
@@ -1,8 +1,8 @@
 /* global describe, it */
 
-const assert = require('assert')
+const { strictEqual } = require('assert')
 const patchResponse = require('../lib/patchResponse')
-const Readable = require('stream').Readable
+const { Readable } = require('readable-stream')
 
 describe('patchResponse', () => {
   // not implemented in Firefox 51
@@ -11,7 +11,7 @@ describe('patchResponse', () => {
 
     patchResponse(res)
 
-    assert.equal(typeof res.body, 'undefined')
+    strictEqual(typeof res.body, 'undefined')
   }) */
 
   it('should use .getReader if available', () => {
@@ -42,7 +42,7 @@ describe('patchResponse', () => {
 
     return new Promise((resolve) => {
       res.body.on('end', () => {
-        assert.equal(touched, true)
+        strictEqual(touched, true)
 
         resolve()
       })
@@ -60,7 +60,7 @@ describe('patchResponse', () => {
 
     res = patchResponse(res)
 
-    assert.equal(stream, res.body)
+    strictEqual(stream, res.body)
   })
 
   it('should emit an error if body is already in use', () => {
@@ -94,7 +94,7 @@ describe('patchResponse', () => {
 
     return new Promise((resolve) => {
       res.body.on('end', () => {
-        assert.equal(touched, true)
+        strictEqual(touched, true)
 
         resolve()
       })

--- a/test/readableToBuffer.js
+++ b/test/readableToBuffer.js
@@ -1,12 +1,12 @@
 /* global describe, it */
 
-const assert = require('assert')
+const { deepStrictEqual, strictEqual } = require('assert')
 const readableToBuffer = require('../lib/readableToBuffer')
 const Readable = require('readable-stream')
 
 describe('readableToBuffer', () => {
   it('should be a function', () => {
-    assert.equal(typeof readableToBuffer, 'function')
+    strictEqual(typeof readableToBuffer, 'function')
   })
 
   it('should concat multiple chunks into a Buffer', () => {
@@ -18,8 +18,23 @@ describe('readableToBuffer', () => {
       }
     })
 
-    return readableToBuffer(readable).then((buffer) => {
-      assert.deepEqual(buffer, Buffer.from('test1234'))
+    return readableToBuffer(readable).then(buffer => {
+      deepStrictEqual(buffer, Buffer.from('test1234'))
+    })
+  })
+
+  it('should concat multiple string chunks into a string', () => {
+    const readable = new Readable({
+      objectMode: true,
+      read: () => {
+        readable.push('test')
+        readable.push('1234')
+        readable.push(null)
+      }
+    })
+
+    return readableToBuffer(readable).then(str => {
+      strictEqual(str, 'test1234')
     })
   })
 })

--- a/test/support/browser.js
+++ b/test/support/browser.js
@@ -1,1 +1,4 @@
-module.exports = {}
+module.exports = {
+  init: () => Promise.resolve(),
+  stop: () => Promise.resolve()
+}

--- a/test/support/server.js
+++ b/test/support/server.js
@@ -1,8 +1,9 @@
-const Promise = require('bluebird')
 const express = require('express')
+const ExpressAsPromise = require('express-as-promise')
 const path = require('path')
 
-const app = express()
+const server = new ExpressAsPromise()
+const app = server.app
 
 app.use(express.static(path.join(__dirname, '../../.build/')))
 app.use(express.static(path.join(__dirname, 'public')))
@@ -13,7 +14,11 @@ app.get('/plain-text', (req, res) => {
 })
 
 function init () {
-  return Promise.promisify(app.listen, {context: app})(8081, 'localhost')
+  return server.listen(8081, 'localhost')
+}
+
+init.stop = () => {
+  return server.stop()
 }
 
 init().then(function () {


### PR DESCRIPTION
- switched from `isomorphic-fetch` to `cross-fetch` as base `fetch` implementation
- switched from `browserify` to `webpack`
- upgraded dependencies