### PR TITLE
separate export for browser and node

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,4 @@
 language: node_js
 node_js:
-  - "8"
   - "10"
   - "12"

--- a/browser.js
+++ b/browser.js
@@ -1,0 +1,15 @@
+const crossFetch = require('cross-fetch')
+const patchRequest = require('./lib/patchRequest')
+const patchResponse = require('./lib/patchResponse')
+
+function fetch (url, options) {
+  return patchRequest(options).then((options) => {
+    return crossFetch(url, options).then((res) => {
+      return patchResponse(res)
+    })
+  })
+}
+
+fetch.Headers = crossFetch.Headers
+
+module.exports = fetch

--- a/index.js
+++ b/index.js
@@ -1,15 +1,1 @@
-const crossFetch = require('cross-fetch')
-const patchRequest = require('./lib/patchRequest')
-const patchResponse = require('./lib/patchResponse')
-
-function fetch (url, options) {
-  return patchRequest(options).then((options) => {
-    return crossFetch(url, options).then((res) => {
-      return patchResponse(res)
-    })
-  })
-}
-
-fetch.Headers = crossFetch.Headers
-
-module.exports = fetch
+module.exports = require('cross-fetch')

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "description": "Node streams for fetch",
   "main": "index.js",
   "browser": {
+    "./index.js": "./browser.js",
     "./test/support/server": "./test/support/browser"
   },
   "scripts": {


### PR DESCRIPTION
Patch only in browser environments and directly forward `cross-fetch` in Node.js.